### PR TITLE
Fix setting a custom markdown engine in multithreaded environments

### DIFF
--- a/lib/maildown/markdown_engine.rb
+++ b/lib/maildown/markdown_engine.rb
@@ -5,11 +5,11 @@ module Maildown
     end
 
     def self.set(&block)
-      Thread.current[:maildown_markdown_engine_block] = block
+      @maildown_markdown_engine_block = block
     end
 
     def self.block
-      Thread.current[:maildown_markdown_engine_block] || default
+      @maildown_markdown_engine_block || default
     end
 
     def self.default

--- a/test/unit/markdown_engine_test.rb
+++ b/test/unit/markdown_engine_test.rb
@@ -23,4 +23,15 @@ class MarkdownEngineTest < ActiveSupport::TestCase
     end
     thread.join
   end
+
+  test "custom engine works in multiple threads" do
+    Maildown::MarkdownEngine.set do |text|
+      "foo: #{text}"
+    end
+
+    thread = Thread.new do
+      assert_equal "foo: bar", Maildown::MarkdownEngine.to_html("bar")
+    end
+    thread.join
+  end
 end


### PR DESCRIPTION
Fixes #6 

Please let me know, if there is a better way of setting/memoizing the config block - I am all ears.