### PR TITLE
Allow config of custom text renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ Once you've got a file named `.md.erb` in your mailer directory, I recommend ver
 Maildown uses [kramdown](https://github.com/gettalong/kramdown) by default.
 Kramdown is pure ruby, so it runs the same across all ruby implementations:
 jruby, rubinius, MRI, etc. You can configure another parser if you like using
-the `Maildown::MarkdownEngine.set` method and pasing it a block.
+the `Maildown::MarkdownEngine.set_html` method and pasing it a block.
 
 For example, if you wanted to use Redcarpet you could set it like this:
 
 ```ruby
-Maildown::MarkdownEngine.set do |text|
+Maildown::MarkdownEngine.set_html do |text|
   carpet = Redcarpet::Markdown.new(Redcarpet::Render::HTML, {})
   carpet.render(text).html_safe
 end
@@ -48,6 +48,16 @@ end
 
 When maildown needs an html document the block will be called with the markdown
 text. The result should be html.
+
+You can also customize the renderer for plain text. By default the text is 
+passed through unmodified, but you may wish to use Kramdown to strip HTML tags,
+unify formatting etc.
+
+```ruby
+Maildown::MarkdownEngine.set_text do |text|
+  Kramdown::Document.new(text).tap(&:to_remove_html_tags).to_kramdown
+end
+```
 
 ## Helpers in Markdown files
 

--- a/lib/maildown/markdown_engine.rb
+++ b/lib/maildown/markdown_engine.rb
@@ -1,21 +1,44 @@
+require 'active_support'
+
 module Maildown
   module MarkdownEngine
     def self.to_html(string)
-      block.call(string)
+      html_block.call(string)
+    end
+
+    def self.to_text(string)
+      text_block.call(string)
     end
 
     def self.set(&block)
-      @maildown_markdown_engine_block = block
+      set_html(&block)
+    end
+    singleton_class.deprecate set: :set_html
+
+    def self.set_html(&block)
+      @maildown_markdown_engine_html_block = block
     end
 
-    def self.block
-      @maildown_markdown_engine_block || default
+    def self.set_text(&block)
+      @maildown_markdown_engine_text_block = block
     end
 
-    def self.default
+    def self.html_block
+      @maildown_markdown_engine_html_block || default_html_block
+    end
+
+    def self.text_block
+      @maildown_markdown_engine_text_block || default_text_block
+    end
+
+    def self.default_html_block
       require 'kramdown' unless defined? Kramdown
 
       ->(string) { Kramdown::Document.new(string).to_html }
+    end
+
+    def self.default_text_block
+      ->(string) { string }
     end
   end
 end

--- a/lib/maildown/markdown_engine.rb
+++ b/lib/maildown/markdown_engine.rb
@@ -1,5 +1,3 @@
-require 'active_support'
-
 module Maildown
   module MarkdownEngine
     def self.to_html(string)
@@ -10,13 +8,17 @@ module Maildown
       text_block.call(string)
     end
 
+    def self.set_html(&block)
+      @maildown_markdown_engine_html_block = block
+    end
+
     def self.set(&block)
       set_html(&block)
     end
-    singleton_class.deprecate set: :set_html
 
-    def self.set_html(&block)
-      @maildown_markdown_engine_html_block = block
+    class << self
+      extend Gem::Deprecate
+      deprecate :set, :set_html, 2017, 6
     end
 
     def self.set_text(&block)

--- a/lib/maildown/md.rb
+++ b/lib/maildown/md.rb
@@ -13,7 +13,7 @@ module Maildown
     end
 
     def to_text
-      string
+      Maildown::MarkdownEngine.to_text(string)
     end
 
     def to_html


### PR DESCRIPTION
As discussed in #26, add another config block for custom text processing, e.g. stripping HTML tags or unifying formatting.

I aimed to keep functionality and API the same or similar so that upgrading is a non-issue. A cleaner config mechanism could be implemented, though this way is pretty flexible so I left it as is.

Previously there was `Maildown::MarkdownEngine#set`, now there are separate `set_html` and `set_text`. The names could be clearer, but this is most similar to the old name.

Open to suggestions if you want to do something more radical.

Tests weren't passing previously, stuff needs adding to Gemfile maybe?