### PR TITLE
Improving Instantiation time on Maildown::Md

### DIFF
--- a/lib/maildown/md.rb
+++ b/lib/maildown/md.rb
@@ -5,8 +5,8 @@ module Maildown
     # responses is an array of hashes containing a body: and :content_type
     def initialize(responses)
       @responses  = responses.reject {|r| r[:content_type] == Mime[:html].to_s || r[:content_type] == Mime[:text].to_s }
-      md_response = responses.detect {|r| r[:content_type] == Mime[:md].to_s }
-      if md_response.present?
+      md_response = @responses.detect {|r| r[:content_type] == Mime[:md].to_s }
+      if md_response
         @string = md_response[:body]
         # Match beginning whitespace but not newline http://rubular.com/r/uCXQ58OOC8
         @string.gsub!(/^[^\S\n]+/, ''.freeze) if Maildown.allow_indentation


### PR DESCRIPTION
A minimal change for a 5% reduction time of instantiation (on my local testing/micro-benchmarking)

Using 2 facts/hints:
  - Instead of #detect the original responses, use the reduced one which already has excluded :html and :text
  - Since #detect would return nil or the founded hash, is safe to use ruby falsy way instead of Rails way.