### PR TITLE
Fix compiled templates

### DIFF
--- a/lib/maildown/ext/action_mailer.rb
+++ b/lib/maildown/ext/action_mailer.rb
@@ -45,10 +45,15 @@ class ActionMailer::Base
     return templates if templates.first.handler != Maildown::Handlers::Markdown
 
     html_template = templates.first
-    text_template = html_template.dup
-    formats = html_template.formats.dup.tap { |f| f.delete(:html) }
+    text_template = html_template.instance_variable_get(:"@maildown_text_template")
+    if text_template.nil?
+      text_template = html_template.dup
+      formats = html_template.formats.dup.tap { |f| f.delete(:html) }
 
-    text_template.formats = formats
+      text_template.formats = formats
+      html_template.instance_variable_set(:"@maildown_text_template", text_template)
+    end
+
     return [html_template, text_template]
   end
 end

--- a/test/integration/double_compile_test.rb
+++ b/test/integration/double_compile_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class DoubleCompileTest < ActionMailer::TestCase
+
+  def test_rendering_the_same_layout_twice_works
+    email = UserNoLayoutMailer.welcome.deliver_now
+    assert !ActionMailer::Base.deliveries.empty?
+    # Test the body of the sent email contains what we expect it to
+
+    body_contents = /<h2 id="welcome">Welcome!<\/h2>/
+    assert_match body_contents,       email.html_part.body.to_s
+
+    body_contents = /## Welcome!/
+    assert_match body_contents,       email.text_part.body.to_s
+
+    email = UserNoLayoutMailer.welcome.deliver_now
+    assert !ActionMailer::Base.deliveries.empty?
+    # Test the body of the sent email contains what we expect it to
+
+    body_contents = /<h2 id="welcome">Welcome!<\/h2>/
+    assert_match body_contents,       email.html_part.body.to_s
+
+    body_contents = /## Welcome!/
+    assert_match body_contents,       email.text_part.body.to_s
+  end
+end


### PR DESCRIPTION
Fixes a bug where text emails render fine the first time, but then are empty the second time.

Templates in rails will be “compiled”, this means their original source is removed and a compiled flag is added. This is good for performance, but it also means calling `dup` on the result of `original_each_template` the first time, gives a very different result than calling dup on `original_each_template` the second time since it has already been “compiled”.

I fixed this by storing the “text” template inside of the “html” template by setting an instance variable. This means that the exact same template for text emails will be used on the first, second, and every other call.