### PR TITLE
Remove warning about non-existent instance var

### DIFF
--- a/lib/maildown/ext/action_mailer.rb
+++ b/lib/maildown/ext/action_mailer.rb
@@ -45,8 +45,9 @@ class ActionMailer::Base
     return templates if templates.first.handler != Maildown::Handlers::Markdown
 
     html_template = templates.first
-    text_template = html_template.instance_variable_get(:"@maildown_text_template")
-    if text_template.nil?
+    if html_template.instance_variable_defined?(:"@maildown_text_template")
+       text_template = html_template.instance_variable_get(:"@maildown_text_template")
+    else
       text_template = html_template.dup
       formats = html_template.formats.dup.tap { |f| f.delete(:html) }
 


### PR DESCRIPTION
In the current code the first time a template is rendered you will get this warning:

```
./Users/rschneeman/Documents/projects/maildown/lib/maildown/ext/action_mailer.rb:48: warning: instance variable @maildown_text_template not initialized
```

This is because `@maildown_text_template` is not yet initialized. Instead, we can check to see if it exists first, before trying to use it using `instance_variable_defined?`.