### PR TITLE
Remove an Action View deprecation in Rails 6

### DIFF
--- a/lib/maildown/handlers/markdown.rb
+++ b/lib/maildown/handlers/markdown.rb
@@ -24,9 +24,14 @@ module Maildown
       # This handler takes care of both text and html email templates
       # by inspectig the available `"formats"` and rendering the
       # markdown to HTML if one of the formats is `:html`.
-      def self.call(template)
+      def self.call(template, source = nil)
+        # The interface of template handlers changed in Rails 6.0 and the
+        # source is passed as an argument. This check is here for compatibility
+        # with Rails 5.0+.
+        source ||= template.source
+
         # Match beginning whitespace but not newline http://rubular.com/r/uCXQ58OOC8
-        template.source.gsub!(/^[^\S\n]+/, ''.freeze) if Maildown.allow_indentation
+        source.gsub!(/^[^\S\n]+/, ''.freeze) if Maildown.allow_indentation
 
         compiled_source = erb_handler.call(template)
 


### PR DESCRIPTION
We're seeing a bunch of Action View work for Rails 6 and template handlers are changing their interface.

Fixes the following warning:

```shell
$ bundle exec rails s
DEPRECATION WARNING: Single arity template handlers are deprecated.  Template handlers must
now accept two parameters, the view object and the source for the view object.
Change:
  >> Module#call(template)
To:
  >> Module#call(template, source)
 (called from <main> at /Users/genadi/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/maildown-3.0.2/lib/maildown/handlers/markdown.rb:45)
```